### PR TITLE
Add the skeleton for an initial plugin for spawners and register it as a project entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,4 +128,4 @@ src = "pytest_jupyterhub/_version.py"
 
 # specify plugin entrypoints
 [project.entry-points.pytest11]
-jupyterhub-spawners = "jupyterhub_spawners"
+jupyterhub-spawners-plugin = "pytest_jupyterhub.jupyterhub_spawners"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
+    "Framework :: Pytest"
 ]
 # Lists the packages and pins them to a version that your project depends on
 dependencies = [
@@ -36,8 +37,8 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest>=7.2.0",
-    "pytest-cov",
-    "pytest-asyncio>=0.20.3",
+    "pytest-cov>=4.0.0",
+    "pytest-asyncio>=0.20.3"
 ]
 
 [project.urls]
@@ -124,3 +125,7 @@ tag_template = "{new_version}"
 
 [[tool.tbump.file]]
 src = "pytest_jupyterhub/_version.py"
+
+# specify plugin entrypoints
+[project.entry-points.pytest11]
+jupyterhub-spawners = "jupyterhub_spawners"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ tag_template = "{new_version}"
 [[tool.tbump.file]]
 src = "pytest_jupyterhub/_version.py"
 
-# specify plugin entrypoints
+# specify project entrypoints to make each plugin discoverable by pytest
+# ref: https://docs.pytest.org/en/latest/how-to/writing_plugins.html#making-your-plugin-installable-by-others
 [project.entry-points.pytest11]
 jupyterhub-spawners-plugin = "pytest_jupyterhub.jupyterhub_spawners"

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -5,6 +5,7 @@ can be used to test different spawner implementations
 
 from pytest import fixture
 
+
 @fixture
 def app_for_spawners():
     pass

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -1,0 +1,10 @@
+""" 
+This plugin module will create a lightweight jupyterhub application that
+can be used to test different spawner implementations
+"""
+
+from pytest import fixture
+
+@fixture
+def app_for_spawners():
+    pass


### PR DESCRIPTION
- created an initial plugin module: `jupyterhub_spawners.py`
- specified the plugin entry point within `pyproject.toml`
- pinned `pytest-cov` package to the latest version
- extended the `classifiers` section to include the Pytest Framework

reference https://github.com/jupyterhub/pytest-jupyterhub/issues/13
closes #14 