### PR TITLE
add initial app_for_spawners fixture

### DIFF
--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -3,9 +3,48 @@ This plugin module will create a lightweight jupyterhub application that
 can be used to test different spawner implementations
 """
 
+import os
+import sys
+from unittest import mock
 from pytest import fixture
+from jupyterhub.jupterhub.mocking import MockHub
 
+KEYTAB_PATH = "/home/testuser/testuser.keytab"
+HAS_KERBEROS = os.path.exists(KEYTAB_PATH)
 
-@fixture
-def app_for_spawners():
-    pass
+@fixture(scope='module')
+def ssl_tmpdir(tmpdir_factory):
+    return tmpdir_factory.mktemp('ssl')
+
+@fixture(scope='module')
+async def app_for_spawners(request, ssl_tmpdir):
+    kwargs = dict()
+    ssl_enabled = getattr(
+        request.module, 'ssl_enabled', os.environ.get('SSL_ENABLED', False)
+        )
+
+    if ssl_enabled:
+        kwargs.update(dict(internal_ssl=True, internal_certs_location=str(ssl_tmpdir)))
+
+    mocked_app = MockHub.instance(**kwargs)
+
+    await mocked_app.initialize([])
+    await mocked_app.start()
+
+    try:
+        with mock.patch.dict(
+            mocked_app.tornado_settings,
+            {'spawner_class': mocked_app.__class__.__name__}
+        ):
+            if HAS_KERBEROS:
+                mocked_app.config.__class__.__name__.principal = 'test_user'
+                mocked_app.config.__class__.__name__.keytab = KEYTAB_PATH
+            yield mocked_app
+    finally:
+        mocked_app.log.handlers = []
+        MockHub.clear_instance()
+        try:
+            mocked_app.stop()
+        except Exception as e:
+            print("Error stopping Hub: %s" % e, file=sys.stderr)
+            

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -3,48 +3,28 @@ This plugin module will create a lightweight jupyterhub application that
 can be used to test different spawner implementations
 """
 
-import os
 import sys
-from unittest import mock
-from pytest import fixture
+
+import pytest
 from jupyterhub.jupterhub.mocking import MockHub
 
-KEYTAB_PATH = "/home/testuser/testuser.keytab"
-HAS_KERBEROS = os.path.exists(KEYTAB_PATH)
 
-@fixture(scope='module')
-def ssl_tmpdir(tmpdir_factory):
-    return tmpdir_factory.mktemp('ssl')
+@pytest.fixture
+def app_for_spawners(request):
+    mocked_app = MockHub()
 
-@fixture(scope='module')
-async def app_for_spawners(request, ssl_tmpdir):
-    kwargs = dict()
-    ssl_enabled = getattr(
-        request.module, 'ssl_enabled', os.environ.get('SSL_ENABLED', False)
-        )
+    async def make_app():
+        await mocked_app.initialize([])
+        await mocked_app.start()
 
-    if ssl_enabled:
-        kwargs.update(dict(internal_ssl=True, internal_certs_location=str(ssl_tmpdir)))
-
-    mocked_app = MockHub.instance(**kwargs)
-
-    await mocked_app.initialize([])
-    await mocked_app.start()
-
-    try:
-        with mock.patch.dict(
-            mocked_app.tornado_settings,
-            {'spawner_class': mocked_app.__class__.__name__}
-        ):
-            if HAS_KERBEROS:
-                mocked_app.config.__class__.__name__.principal = 'test_user'
-                mocked_app.config.__class__.__name__.keytab = KEYTAB_PATH
-            yield mocked_app
-    finally:
+    def fin():
         mocked_app.log.handlers = []
         MockHub.clear_instance()
         try:
             mocked_app.stop()
         except Exception as e:
             print("Error stopping Hub: %s" % e, file=sys.stderr)
-            
+
+    request.addfinalizer(fin)
+    make_app()
+    return mocked_app

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -3,10 +3,11 @@ This plugin module will create a lightweight jupyterhub application that
 can be used to test different spawner implementations
 """
 
+import asyncio
 import sys
 
 import pytest
-from jupyterhub.jupterhub.mocking import MockHub
+from jupyterhub.jupyterhub.mocking import MockHub
 
 
 @pytest.fixture
@@ -26,5 +27,5 @@ def app_for_spawners(request):
             print("Error stopping Hub: %s" % e, file=sys.stderr)
 
     request.addfinalizer(fin)
-    make_app()
+    asyncio.run(make_app())
     return mocked_app


### PR DESCRIPTION
- created an initial `app_for_spawners` fixture that performs the following tasks: 
    - creates an instance of a mocked `JupyterHub` application with ssl protocol enabled if the value of the `SSL_ENABLED` environment variable is present
    - initializes and starts the mocked application with the keyword arguments
    - configures the mocked application to use the spawner class of the spawner it is being used in
    - configures the spawner to utilize the Kerberos protocol if the `KEYTAB_PATH` exists
    - yields the mocked application for testing session
    - disconnects the logs, clears the mocked instance and stops it when testing is completed
 
Reference https://github.com/jupyterhub/pytest-jupyterhub/issues/13
