### PR TITLE
Create fixture that configures JupyterHub to use the Spawner class

### DIFF
--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -5,9 +5,18 @@ can be used to test different spawner implementations
 
 import pytest
 from jupyterhub.spawner import Spawner
+from traitlets.config import Config
 
 
 @pytest.fixture
 def spawner_class():
     """Allows tests to setup the Spawner class that will be used by the hub."""
     return Spawner
+
+
+@pytest.fixture
+def jupyterhub_spawner_config(spawner_class):
+    """Configures JupyterHub to use the Spawner class"""
+    c = Config()
+    c.JupyterHub.spawner_class = spawner_class
+    return c

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -16,7 +16,6 @@ def spawner_class():
 
 @pytest.fixture
 def jupyterhub_spawner_class_config(spawner_class):
-    """Configures JupyterHub to use the Spawner class"""
-    c = Config()
-    c.JupyterHub.spawner_class = spawner_class
-    return c
+    """Configures JupyterHub to use the Spawner class specified in the spawner_class fixture."""
+    spawner_class_config = {"JupyterHub": {"spawner_class": spawner_class}}
+    return Config(spawner_class_config)

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -15,7 +15,7 @@ def spawner_class():
 
 
 @pytest.fixture
-def jupyterhub_spawner_config(spawner_class):
+def jupyterhub_spawner_class_config(spawner_class):
     """Configures JupyterHub to use the Spawner class"""
     c = Config()
     c.JupyterHub.spawner_class = spawner_class


### PR DESCRIPTION
- created a fixture that returns a Config object that configures JupyterHub to use the base Spawner class

reference #20 