### PR TITLE
add fixture that creates an instance of JupyterHub

### DIFF
--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -34,8 +34,11 @@ def spawner_config():
 @pytest.fixture
 def app_for_spawners(request, jupyterhub_spawner_class_config, spawner_config):
     """Creates an instance of a JupyterHub application that can be used by different spawner implementation test suites"""
-    config = jupyterhub_spawner_class_config.merge(spawner_config)
-    mocked_app = MockHub.instance(config)
+    config = jupyterhub_spawner_class_config
+    for key, value in spawner_config.items():
+        config[key] = value
+
+    mocked_app = MockHub.instance(config=config)
 
     async def make_app():
         """Initializes the mocked application and starts it"""

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -34,9 +34,7 @@ def spawner_config():
 @pytest.fixture
 def app_for_spawners(request, jupyterhub_spawner_class_config, spawner_config):
     """Creates an instance of a JupyterHub application that can be used by different spawner implementation test suites"""
-    config = jupyterhub_spawner_class_config
-    for key, value in spawner_config.items():
-        config[key] = value
+    config = jupyterhub_spawner_class_config.merge(spawner_config)
 
     mocked_app = MockHub.instance(config=config)
 

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -3,8 +3,12 @@ This plugin module will create a lightweight jupyterhub application that
 can be used to test different spawner implementations
 """
 
+import asyncio
+import sys
+
 import pytest
 from jupyterhub.spawner import Spawner
+from jupyterhub.tests.mocking import MockHub
 from traitlets.config import Config
 
 
@@ -25,3 +29,28 @@ def jupyterhub_spawner_class_config(spawner_class):
 def spawner_config():
     """Allows tests to setup configurations that are specific to the spawner implementation"""
     return Config()
+
+
+@pytest.fixture
+def app_for_spawners(request, jupyterhub_spawner_class_config, spawner_config):
+    """Creates an instance of a JupyterHub application that can be used by different spawner implementation test suites"""
+    config = jupyterhub_spawner_class_config.merge(spawner_config)
+    mocked_app = MockHub.instance(config)
+
+    async def make_app():
+        """Initializes the mocked application and starts it"""
+        await mocked_app.initialize([])
+        await mocked_app.start()
+
+    def fin():
+        """Disconnects logging during cleanup because pytest closes captured FDs prematurely"""
+        mocked_app.log.handlers = []
+        MockHub.clear_instance()
+        try:
+            mocked_app.stop()
+        except Exception as e:
+            print("Error stopping Hub: %s" % e, file=sys.stderr)
+
+    request.addfinalizer(fin)
+    asyncio.run(make_app())
+    return mocked_app

--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -34,9 +34,9 @@ def spawner_config():
 @pytest.fixture
 def app_for_spawners(request, jupyterhub_spawner_class_config, spawner_config):
     """Creates an instance of a JupyterHub application that can be used by different spawner implementation test suites"""
-    config = jupyterhub_spawner_class_config.merge(spawner_config)
-
-    mocked_app = MockHub.instance(config=config)
+    final_config = jupyterhub_spawner_class_config
+    final_config.merge(spawner_config)
+    mocked_app = MockHub.instance(config=final_config)
 
     async def make_app():
         """Initializes the mocked application and starts it"""


### PR DESCRIPTION
- created a fixture that creates an instance of `JupyterHub` using the `jupyterhub_spawner_class_config` and `spawner_config` fixtures.
- the `mocked_app` object is then initialized and started
- the `mocked_app` object is finally stopped

Reference #13 