### PR TITLE
Add contributing instructions

### DIFF
--- a/docs/source/contributing/docs.md
+++ b/docs/source/contributing/docs.md
@@ -1,0 +1,74 @@
+(contributing-docs)=
+
+# Contributing Documentation
+
+Documentation is often more important than code. This page helps you get set up on how to contribute to Pytest JupyterHub's documentation.
+
+## Building documentation locally
+
+We use [sphinx](https://www.sphinx-doc.org) to build our documentation. It takes our documentation source files (written in [markdown](https://daringfireball.net/projects/markdown/) or [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) &
+stored under the `docs/source` directory) and converts it into various
+formats for people to read. To make sure the documentation you write or
+change renders correctly, it is good practice to test it locally.
+
+1. Make sure you have successfully completed {ref}`contributing/setup`.
+
+2. Install the packages required to build the docs.
+
+   ```bash
+   python3 -m pip install -r docs/requirements.txt
+   ```
+
+3. Build the html version of the docs. This is the most commonly used
+   output format, so verifying it renders correctly is usually good
+   enough.
+
+   ```bash
+   cd docs
+   make html
+   ```
+
+   This step will display any syntax or formatting errors in the documentation,
+   along with the filename / line number in which they occurred. Fix them,
+   and re-run the `make html` command to re-render the documentation.
+
+4. View the rendered documentation by opening `_build/html/index.html` in
+   a web browser.
+
+   :::{tip}
+   **On Windows**, you can open a file from the terminal with `start <path-to-file>`.
+
+   **On macOS**, you can do the same with `open <path-to-file>`.
+
+   **On Linux**, you can do the same with `xdg-open <path-to-file>`.
+
+   After opening index.html in your browser you can just refresh the page whenever
+   you rebuild the docs via `make html`
+   :::
+
+(contributing-docs-conventions)=
+
+## Documentation conventions
+
+This section lists various conventions we use in our documentation. This is a
+living document that grows over time, so feel free to add to it / change it!
+
+Our entire documentation does not yet fully conform to these conventions yet,
+so help in making it so would be appreciated!
+
+### `pip` invocation
+
+There are many ways to invoke a `pip` command, we recommend the following
+approach:
+
+```bash
+python3 -m pip
+```
+
+This invokes pip explicitly using the python3 binary that you are
+currently using. This is the **recommended way** to invoke pip
+in our documentation, since it is least likely to cause problems
+with python3 and pip being from different environments.
+
+For more information on how to invoke `pip` commands, see
+[the pip documentation](https://pip.pypa.io/en/stable/).

--- a/docs/source/contributing/docs.md
+++ b/docs/source/contributing/docs.md
@@ -6,10 +6,8 @@ Documentation is often more important than code. This page helps you get set up 
 
 ## Building documentation locally
 
-We use [sphinx](https://www.sphinx-doc.org) to build our documentation. It takes our documentation source files (written in [markdown](https://daringfireball.net/projects/markdown/) or [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) &
-stored under the `docs/source` directory) and converts it into various
-formats for people to read. To make sure the documentation you write or
-change renders correctly, it is good practice to test it locally.
+We use [sphinx](https://www.sphinx-doc.org) to build our documentation. It takes our documentation source files (written in [markdown](https://daringfireball.net/projects/markdown/) or [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) & stored under the `docs/source` directory) and converts it into various
+formats for people to read. To make sure the documentation you write or change renders correctly, it is good practice to test it locally.
 
 1. Make sure you have successfully completed {ref}`contributing/setup`.
 
@@ -28,9 +26,7 @@ change renders correctly, it is good practice to test it locally.
    make html
    ```
 
-   This step will display any syntax or formatting errors in the documentation,
-   along with the filename / line number in which they occurred. Fix them,
-   and re-run the `make html` command to re-render the documentation.
+   This step will display any syntax or formatting errors in the documentation, along with the filename / line number in which they occurred. Fix them, and re-run the `make html` command to re-render the documentation.
 
 4. View the rendered documentation by opening `_build/html/index.html` in
    a web browser.
@@ -42,8 +38,7 @@ change renders correctly, it is good practice to test it locally.
 
    **On Linux**, you can do the same with `xdg-open <path-to-file>`.
 
-   After opening index.html in your browser you can just refresh the page whenever
-   you rebuild the docs via `make html`
+   After opening index.html in your browser you can just refresh the page whenever you rebuild the docs via `make html`
    :::
 
 (contributing-docs-conventions)=

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -1,0 +1,15 @@
+# Contributing
+
+We want you to contribute to Pytest JupyterHub in ways that are most exciting
+and useful to you. We value documentation, testing, bug reporting & code equally, and are glad to have your contributions in whatever form you wish.
+
+Be sure to first check our [Code of Conduct](https://github.com/jupyter/governance/blob/HEAD/conduct/code_of_conduct.md)
+([reporting guidelines](https://github.com/jupyter/governance/blob/HEAD/conduct/reporting_online.md)), which help keep our community welcoming to as many people as possible.
+
+```{toctree}
+:maxdepth: 2
+
+setup
+docs
+tests
+```

--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -16,7 +16,7 @@ The JupyterHub Pytest Plugin uses [Git](https://git-scm.com) & [GitHub](https://
 
 ## Setting up a development install
 
-When developing JupyterHub, you would need to make changes and be able to instantly view the results of the changes. To achieve that, a developer install is required.
+When developing Pytest JupyterHub, you would need to make changes and be able to instantly test the changes. To achieve that, a developer install is required.
 
 :::{note}
 This guide does not attempt to dictate _how_ development
@@ -41,7 +41,7 @@ a more detailed discussion.
 
    This should return a version number greater than or equal to 3.8.
 
-3. Install an editable version of Pytest JupyterHub and its requirements for development and testing.
+3. Install an editable version of Pytest-JupyterHub and its requirements for development and testing.
 
    ```bash
    python3 -m pip install --editable ".[test]"

--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -1,0 +1,56 @@
+(contributing/setup)=
+
+# Setting up a development install
+
+## System Requirements
+
+The `JupyterHub Pytest Plugin` uses `JupyterHub` which can only run on macOS or Linux operating systems. If you are using Windows, we recommend using [VirtualBox](https://virtualbox.org) or a similar system to run [Ubuntu Linux](https://ubuntu.com) for development.
+
+### Install Python
+
+The JupyterHub Pytest Plugin is written in the [Python](https://python.org) programming language and requires you have at least version 3.8 installed locally. If you haven’t installed Python before, the recommended way to install it is to use [Miniforge](https://github.com/conda-forge/miniforge#download).
+
+### Install git
+
+The JupyterHub Pytest Plugin uses [Git](https://git-scm.com) & [GitHub](https://github.com) for development & collaboration. You need to [install git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) to work on the JupyterHub Pytest Plugin. We also recommend getting a free account on GitHub.com.
+
+## Setting up a development install
+
+When developing JupyterHub, you would need to make changes and be able to instantly view the results of the changes. To achieve that, a developer install is required.
+
+:::{note}
+This guide does not attempt to dictate _how_ development
+environments should be isolated since that is a personal preference and can
+be achieved in many ways, for example, `tox`, `conda`, `docker`, etc. See this
+[forum thread](https://discourse.jupyter.org/t/thoughts-on-using-tox/3497) for
+a more detailed discussion.
+:::
+
+1. Clone the [Pytest JupyterHub](https://github.com/jupyterhub/pytest-jupyterhub) repository to your computer.
+
+   ```bash
+   git clone https://github.com/jupyterhub/pytest-jupyterhub.git
+   cd pytest-jupyterhub
+   ```
+
+2. Make sure the `python` you installed is available to you on the command line.
+
+   ```bash
+   python -V
+   ```
+
+   This should return a version number greater than or equal to 3.8.
+
+3. Install an editable version of Pytest JupyterHub and its requirements for development and testing.
+
+   ```bash
+   python3 -m pip install --editable ".[test]"
+   ```
+
+4. You are now good to go! Run the tests to confirm all required dependencies have been installed correctly.
+
+   ```bash
+   pytest -v --cov=pytest_jupyterhub tests
+   ```
+
+Happy Coding! :)

--- a/docs/source/contributing/tests.md
+++ b/docs/source/contributing/tests.md
@@ -19,12 +19,6 @@ Pytest JupyterHub uses [pytest](https://pytest.org) for all the tests. You can f
 
    This should display progress as it runs all the tests, printing information about any test failures as they occur.
 
-   If you wish to confirm test coverage the run tests with the `--cov` flag:
-
-   ```bash
-   pytest -v --cov=pytest_jupyterhub tests
-   ```
-
 3. You can also run tests in just a specific file:
 
    ```bash
@@ -39,8 +33,7 @@ Pytest JupyterHub uses [pytest](https://pytest.org) for all the tests. You can f
 
    This runs the test with function name `<test-name>` defined in `<test-file-name>`. This is very useful when you are iteratively developing a single test.
 
-   For example, to run the test `test_default_hub_app` in the file `test_jupyterhub_spawners.py`,
-   you would run:
+   For example, to run the test `test_default_hub_app` in the file `test_jupyterhub_spawners.py`, you would run:
 
    ```bash
    pytest -v tests/test_jupyterhub_spawners.py::test_default_hub_app
@@ -85,9 +78,7 @@ Make sure you have completed all the steps in {ref}`contributing/setup` successf
 
 Pytest JupyterHub automatically enforces code formatting. This means that pull requests with changes breaking this formatting will receive a commit from `pre-commit.ci` automatically.
 
-To automatically format code locally, you can install `pre-commit` and register a
-_git hook_ to automatically check with pre-commit before you make a commit if
-the formatting is okay.
+To automatically format code locally, you can install `pre-commit` and register a _git hook_ to automatically check with pre-commit before you make a commit if the formatting is okay.
 
 ```bash
 pip install pre-commit
@@ -106,5 +97,8 @@ pre-commit run --all-files
 
 To skip pre-commit checks use the tag `--no-verify` in your commit.
 
-You may also install [black integration](https://github.com/psf/black#editor-integration)
-into your text editor to format code automatically.
+```bash
+git commit -m "initial commit" --no-verify
+```
+
+You may also install [black integration](https://github.com/psf/black#editor-integration) into your text editor to format code automatically.

--- a/docs/source/contributing/tests.md
+++ b/docs/source/contributing/tests.md
@@ -1,0 +1,110 @@
+(contributing-tests)=
+
+# Testing Pytest JupyterHub and Linting code
+
+Unit testing helps to validate that Pytest JupyterHub works the way we think it does, and continues to do so when changes occur. They also help communicate
+precisely what we expect our code to do.
+
+Pytest JupyterHub uses [pytest](https://pytest.org) for all the tests. You can find them under the [pytest-jupyterhub/tests](https://github.com/jupyterhub/pytest-jupyterhub/tree/main/tests) directory in the git repository.
+
+## Running the tests
+
+1. Make sure you have completed {ref}`contributing/setup`.
+
+2. You can run all tests in Pytest JupyterHub
+
+   ```bash
+   pytest -v tests
+   ```
+
+   This should display progress as it runs all the tests, printing information about any test failures as they occur.
+
+   If you wish to confirm test coverage the run tests with the `--cov` flag:
+
+   ```bash
+   pytest -v --cov=pytest_jupyterhub tests
+   ```
+
+3. You can also run tests in just a specific file:
+
+   ```bash
+   pytest -v tests/<test-file-name>
+   ```
+
+4. To run a specific test only, you can do:
+
+   ```bash
+   pytest -v tests/<test-file-name>::<test-name>
+   ```
+
+   This runs the test with function name `<test-name>` defined in `<test-file-name>`. This is very useful when you are iteratively developing a single test.
+
+   For example, to run the test `test_default_hub_app` in the file `test_jupyterhub_spawners.py`,
+   you would run:
+
+   ```bash
+   pytest -v tests/test_jupyterhub_spawners.py::test_default_hub_app
+   ```
+
+   For more details, refer to the [pytest usage documentation](https://pytest.readthedocs.io/en/latest/usage.html).
+
+### The Pytest-Asyncio Plugin
+
+When testing the various JupyterHub components and their various implementations, it sometimes becomes necessary to have a running instance of JupyterHub to test against.
+The [`app`](https://github.com/jupyterhub/jupyterhub/blob/270b61992143b29af8c2fab90c4ed32f2f6fe209/jupyterhub/tests/conftest.py#L60) fixture mocks a JupyterHub application for use in testing by:
+
+- enabling ssl if internal certificates are available
+- creating an instance of [MockHub](https://github.com/jupyterhub/jupyterhub/blob/270b61992143b29af8c2fab90c4ed32f2f6fe209/jupyterhub/tests/mocking.py#L221) using any provided configurations as arguments
+- initializing the mocked instance
+- starting the mocked instance
+- finally, a registered finalizer function performs a cleanup and stops the mocked instance
+
+The JupyterHub test suite uses the [pytest-asyncio plugin](https://pytest-asyncio.readthedocs.io/en/latest/) that handles [event-loop](https://docs.python.org/3/library/asyncio-eventloop.html) integration in [Tornado](https://www.tornadoweb.org/en/stable/) applications. This allows for the use of top-level awaits when calling async functions or [fixtures](https://docs.pytest.org/en/6.2.x/fixture.html#what-fixtures-are) during testing. All test functions and fixtures labelled as `async` will run on the same event loop.
+
+```{note}
+With the introduction of [top-level awaits](https://piccolo-orm.com/blog/top-level-await-in-python/), the use of the `io_loop` fixture of the [pytest-tornado plugin](https://www.tornadoweb.org/en/stable/ioloop.html) is no longer necessary. It was initially used to call coroutines. With the upgrades made to `pytest-asyncio`, this usage is now deprecated. It is now, only utilized within the JupyterHub test suite to ensure complete cleanup of resources used during testing such as open file descriptors. This is demonstrated in this [pull request](https://github.com/jupyterhub/jupyterhub/pull/4332).
+More information is provided below.
+```
+
+One of the general goals of the [JupyterHub Pytest Plugin project](https://github.com/jupyterhub/pytest-jupyterhub) is to ensure the MockHub cleanup fully closes and stops all utilized resources during testing so the use of the `io_loop` fixture for teardown is not necessary. This was highlighted in this [issue](https://github.com/jupyterhub/pytest-jupyterhub/issues/30)
+
+For more information on asyncio and event-loops, here are some resources:
+
+- **Read**: [Introduction to the Python event loop](https://www.pythontutorial.net/python-concurrency/python-event-loop)
+- **Read**: [Overview of Async IO in Python 3.7](https://stackabuse.com/overview-of-async-io-in-python-3-7)
+- **Watch**: [Asyncio: Understanding Async / Await in Python](https://www.youtube.com/watch?v=bs9tlDFWWdQ)
+- **Watch**: [Learn Python's AsyncIO #2 - The Event Loop](https://www.youtube.com/watch?v=E7Yn5biBZ58)
+
+## Troubleshooting Test Failures
+
+### All the tests are failing
+
+Make sure you have completed all the steps in {ref}`contributing/setup` successfully.
+
+## Code formatting and linting
+
+Pytest JupyterHub automatically enforces code formatting. This means that pull requests with changes breaking this formatting will receive a commit from `pre-commit.ci` automatically.
+
+To automatically format code locally, you can install `pre-commit` and register a
+_git hook_ to automatically check with pre-commit before you make a commit if
+the formatting is okay.
+
+```bash
+pip install pre-commit
+pre-commit install --install-hooks
+```
+
+To run pre-commit manually you would do:
+
+```bash
+# check for changes to code not yet committed
+pre-commit run
+
+# check for changes also in already committed code
+pre-commit run --all-files
+```
+
+To skip pre-commit checks use the tag `--no-verify` in your commit.
+
+You may also install [black integration](https://github.com/psf/black#editor-integration)
+into your text editor to format code automatically.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -26,6 +26,12 @@ plugins/index
 
 ```{toctree}
 :maxdepth: 2
+:caption: Contributing
+contributing/index
+```
+
+```{toctree}
+:maxdepth: 2
 :caption: About JupyterHub Pytest Plugin
 changelog
 ```


### PR DESCRIPTION
- These documents were created by reusing the [JupyterHub Contributing Instructions](https://jupyterhub.readthedocs.io/en/stable/contributing/index.html) and modifying them to fit the specifics of [Pytest JupyterHub](https://github.com/jupyterhub/pytest-jupyterhub)

Closes #5