### PR TITLE
Add nodejs install instructions

### DIFF
--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -53,10 +53,10 @@ a more detailed discussion.
 
    This should return a version number greater than or equal to 5.0.
 
-3. Install `configurable-http-proxy` (required to run and test the default JupyterHub configuration) and `yarn` (required to build some components):
+3. Install `configurable-http-proxy` (required to run and test the default JupyterHub configuration):
 
    ```bash
-   npm install -g configurable-http-proxy yarn
+   npm install -g configurable-http-proxy
    ```
 
    If you get an error that says `Error: EACCES: permission denied`, you might need to prefix the command with `sudo`.
@@ -64,7 +64,7 @@ a more detailed discussion.
    If you do not have access to sudo, you may instead run the following commands:
 
    ```bash
-   npm install configurable-http-proxy yarn
+   npm install configurable-http-proxy
    export PATH=$PATH:$(pwd)/node_modules/.bin
    ```
 
@@ -73,7 +73,7 @@ a more detailed discussion.
    If you are using conda you can instead run:
 
    ```bash
-   conda install configurable-http-proxy yarn
+   conda install configurable-http-proxy
    ```
 
 4. Install an editable version of Pytest-JupyterHub and its requirements for development and testing.

--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -10,6 +10,12 @@ The [JupyterHub Pytest Plugin](https://github.com/jupyterhub/pytest-jupyterhub) 
 
 The JupyterHub Pytest Plugin is written in the [Python](https://python.org) programming language and requires you have at least version 3.8 installed locally. If you haven’t installed Python before, the recommended way to install it is to use [Miniforge](https://github.com/conda-forge/miniforge#download).
 
+### Install nodejs
+
+[NodeJS 12+](https://nodejs.org/en/) is required for building some JavaScript components. `configurable-http-proxy`, the default proxy implementation for JupyterHub, is written in Javascript. If you have not installed NodeJS before, we recommend installing it in the `miniconda` environment you set up for Python. You can do so with `conda install nodejs`.
+
+Many in the Jupyter community use \[`nvm`\](<https://github.com/nvm-sh/nvm>) to managing node dependencies.
+
 ### Install git
 
 The JupyterHub Pytest Plugin uses [Git](https://git-scm.com) & [GitHub](https://github.com) for development & collaboration. You need to [install git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) to work on the JupyterHub Pytest Plugin. We also recommend getting a free account on GitHub.com.
@@ -33,7 +39,7 @@ a more detailed discussion.
    cd pytest-jupyterhub
    ```
 
-2. Make sure the `python` you installed is available to you on the command line.
+2. Make sure the `python` and `npm` you installed are available to you on the command line.
 
    ```bash
    python -V
@@ -41,13 +47,42 @@ a more detailed discussion.
 
    This should return a version number greater than or equal to 3.8.
 
-3. Install an editable version of Pytest-JupyterHub and its requirements for development and testing.
+   ```bash
+   npm -v
+   ```
+
+   This should return a version number greater than or equal to 5.0.
+
+3. Install `configurable-http-proxy` (required to run and test the default JupyterHub configuration) and `yarn` (required to build some components):
+
+   ```bash
+   npm install -g configurable-http-proxy yarn
+   ```
+
+   If you get an error that says `Error: EACCES: permission denied`, you might need to prefix the command with `sudo`.
+   `sudo` may be required to perform a system-wide install.
+   If you do not have access to sudo, you may instead run the following commands:
+
+   ```bash
+   npm install configurable-http-proxy yarn
+   export PATH=$PATH:$(pwd)/node_modules/.bin
+   ```
+
+   The second line needs to be run every time you open a new terminal.
+
+   If you are using conda you can instead run:
+
+   ```bash
+   conda install configurable-http-proxy yarn
+   ```
+
+4. Install an editable version of Pytest-JupyterHub and its requirements for development and testing.
 
    ```bash
    python3 -m pip install --editable ".[test]"
    ```
 
-4. You are now good to go! Run the tests to confirm all required dependencies have been installed correctly.
+5. You are now good to go! Run the tests to confirm all required dependencies have been installed correctly.
 
    ```bash
    pytest -v --cov=pytest_jupyterhub tests


### PR DESCRIPTION
I wanted to ensure the [setup instructions](https://pytest-jupyterhub.readthedocs.io/en/latest/contributing/setup.html) in the [contributing docs](https://pytest-jupyterhub.readthedocs.io/en/latest/contributing/index.html) work perfectly with no extra steps than stated. 
I realized tests were failing due to the missing `configurable-http-proxy` required by `JupyterHub`.
Added extra steps to install `nodejs`, `configurable-http-proxy` and `yarn`