### PR TITLE
Call JupyterHub.cleanup during teardown

### DIFF
--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -1,4 +1,4 @@
-""" 
+"""
 This plugin module will create a lightweight jupyterhub application that
 can be used to test different spawner implementations
 """
@@ -74,6 +74,9 @@ async def hub_app(configured_mockhub_instance):
     app = MockHub.instance()
     app.log.handlers = []
     try:
+        # cleanup stops spawners, proxy, etc.
+        await app.cleanup()
+
         # Explicitly close the http server socket to not leek any fds
         # Also await app.shutdown_cancel_tasks()
         # Note that this is equivalent to the app.stop() function


### PR DESCRIPTION
should avoid leaving state between runs, like the proxy or spawners

I think this might fix some of the failures in https://github.com/jupyterhub/dockerspawner/pull/476 which for jupyterhub 2.2 are caused by a proxy still being running in tests after the first.