### PR TITLE
Fix rST syntax issue in docstring

### DIFF
--- a/pytest_jupyterhub/jupyterhub_spawners.py
+++ b/pytest_jupyterhub/jupyterhub_spawners.py
@@ -20,6 +20,7 @@ async def configured_mockhub_instance():
     More about factory fixtures at https://docs.pytest.org/en/latest/how-to/fixtures.html#factories-as-fixtures
 
     It should be called like:
+
     .. code-block:: python
 
         def my_test(configured_mockhub_instance):
@@ -49,6 +50,7 @@ async def hub_app(configured_mockhub_instance):
     More about factory fixtures at https://docs.pytest.org/en/latest/how-to/fixtures.html#factories-as-fixtures
 
     It should be called like:
+
     .. code-block:: python
 
         async def my_test(hub_app):


### PR DESCRIPTION
It seems that there is a need for a new line above `.. code-block:` for the section to render properly.

### Before
![image](https://github.com/jupyterhub/pytest-jupyterhub/assets/3837114/6a3cfba4-afe6-48c2-978a-ee18dcb5bf3a)

### After
![image](https://github.com/jupyterhub/pytest-jupyterhub/assets/3837114/bc1ab276-89f8-452e-a2f8-bfb84c4c4cad)
